### PR TITLE
#6: Remove print statements, replace with QgsMessageLog

### DIFF
--- a/geotaggingthread.py
+++ b/geotaggingthread.py
@@ -115,7 +115,11 @@ class GeotaggingThread(QThread):
 
             self.process.start(self.command, self.arguments, QIODevice.ReadOnly)
             if not self.process.waitForFinished(-1):
-                print "Failed to process directory", dirName
+                QgsMessageLog.logMessage(
+                    "Failed to process directory " + dirName,
+                    tag='Geotag and import photos',
+                    level=QgsMessageLog.WARNING
+                )
 
             self.updateProgress.emit()
 
@@ -182,7 +186,11 @@ class GeotaggingThread(QThread):
                                 try:
                                     os.rename(fullPath, os.path.join(root, unicode(newName)))
                                 except OSError, e:
-                                    print e
+                                    QgsMessageLog.logMessage(
+                                        e,
+                                        tag='Geotag and import photos',
+                                        level=QgsMessageLog.CRITICAL
+                                    )
 
                                 self.updateProgress.emit()
 
@@ -194,7 +202,11 @@ class GeotaggingThread(QThread):
                                     break
 
     def geotagError(self, error):
-        print "ERROR:", unicode(error)
+        QgsMessageLog.logMessage(
+            error,
+            tag='Geotag and import photos',
+            level=QgsMessageLog.WARNING
+        )
 
     def stop(self):
         self.mutex.lock()

--- a/importthread.py
+++ b/importthread.py
@@ -62,7 +62,6 @@ class ImportThread(QThread):
     def run(self):
         if self.appendFile:
             layer = self.openExistingLayer()
-            print "LAYER OPENED"
         else:
             layer = self.createNewLayer()
 
@@ -103,7 +102,6 @@ class ImportThread(QThread):
                         # create new feature
                         ft = QgsFeature()
                         ft.setFields(fields)
-                        print "FEATURE INITIALIZED"
 
                         for k, v in md.iteritems():
                             tagName = k.replace("EXIF:", "")

--- a/tagphotosthread.py
+++ b/tagphotosthread.py
@@ -104,7 +104,11 @@ class TagPhotosThread(QThread):
 
             self.process.start(self.command, self.arguments, QIODevice.ReadOnly)
             if not self.process.waitForFinished(-1):
-                print "Failed to process directory", dirName
+                QgsMessageLog.logMessage(
+                    "Failed to process directory " + dirName,
+                    tag='Geotag and import photos',
+                    level=QgsMessageLog.WARNING
+                )
 
             self.updateProgress.emit()
 
@@ -121,7 +125,11 @@ class TagPhotosThread(QThread):
             self.processInterrupted.emit()
 
     def taggingError(self, error):
-        print "ERROR:", unicode(error)
+        QgsMessageLog.logMessage(
+            error,
+            tag='Geotag and import photos',
+            level=QgsMessageLog.WARNING
+        )
 
     def stop(self):
         self.mutex.lock()


### PR DESCRIPTION
Removing `print` statements and replacing them with log messages where appropriate avoids an overflow when the console is not open.